### PR TITLE
add possibility to ignore some pam services for notify

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,5 +35,6 @@ pwsec_common:
   notify_on_login: false
   notify_tg_token_id: ""
   notify_tg_chat_id: ""
+  notify_tg_ignored_pam_services: []
   password_strength: true
   password_reuse: true

--- a/templates/login-notify
+++ b/templates/login-notify
@@ -3,6 +3,15 @@ TOKEN_ID='{{ pwsec.notify_tg_token_id }}'
 CHAT_ID='{{ pwsec.notify_tg_chat_id }}'
 EXT_IP=$(/usr/bin/curl ifconfig.me)
 EXT_IP_MSG="(external IP ${EXT_IP:-cannot be defined reliably})"
+IGNORE_LIST=({% for s in pwsec.notify_tg_ignored_pam_services %} '{{ s }}' {% endfor %})
+
+
+for item in "${IGNORE_LIST[@]}"
+do
+  if [ "$PAM_SERVICE" == "$item" ]; then
+    exit 0
+  fi
+done
 
 
 SUBJECT="<i>${PAM_TYPE} on ${HOSTNAME} ${EXT_IP_MSG} from ${PAM_RHOST:-localhost}\n</i>"


### PR DESCRIPTION
This changes will check every pam services in notify script and compare them with list of ignored services. If one of ignored pam services match with current pam services - script will stop with exit code 0.