### PR TITLE
add-missed-defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 pwsec_host: {}
 pwsec_group: {}
-pwsec_validation: false
+pwsec_validation: true
 pwsec_validation_image: onemind914/pam-validation-ubuntu-sshd:ubuntu20.04
 pwsec_common:
   # Users which never expires

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 pwsec_host: {}
 pwsec_group: {}
+pwsec_validation: false
 pwsec_validation_image: onemind914/pam-validation-ubuntu-sshd:ubuntu20.04
 pwsec_common:
   # Users which never expires

--- a/tasks/pam_validation.yml
+++ b/tasks/pam_validation.yml
@@ -1,11 +1,10 @@
 ---
 - name: Start ssh testing container 
   delegate_to: localhost
-  docker_compose:
+  community.docker.docker_compose_v2:
     state: present
     project_name: pam-ssh-test
     definition:
-      version: '2'
       services:
         ssh:
           image: "{{ pwsec_validation_image }}"


### PR DESCRIPTION
I added the pwsec_validation variable skipped in defaults, which caused the Run expiration check for existing users to crash with an error. Set the default value to false